### PR TITLE
Modified the firmware to send Mac address with device name

### DIFF
--- a/NPG-LITE-BLE/NPG_LITE_BLE.ino
+++ b/NPG-LITE-BLE/NPG_LITE_BLE.ino
@@ -149,7 +149,15 @@ void setup() {
   analogReadResolution(12);
 
   // ----- Initialize BLE -----
-  BLEDevice::init("ESP32_BLE_Device");
+  BLEDevice::init("NPG"); 
+
+  // Retrieve the BLE MAC address
+  String bleMAC = BLEDevice::getAddress().toString().c_str();
+
+  // Set device name
+  String deviceName = "NPG-" + bleMAC;
+  esp_ble_gap_set_device_name(deviceName.c_str());
+
   // Optionally, request a larger MTU:
   BLEDevice::setMTU(111);
 

--- a/NPG-LITE-BLE/NPG_LITE_BLE.ino
+++ b/NPG-LITE-BLE/NPG_LITE_BLE.ino
@@ -152,7 +152,7 @@ void setup() {
   BLEDevice::init("NPG"); 
 
   // Retrieve the BLE MAC address
-  String bleMAC = BLEDevice::getAddress().toString().c_str();
+  String bleMAC = BLEDevice::getAddress().toString();
 
   // Set device name
   String deviceName = "NPG-" + bleMAC;


### PR DESCRIPTION
Modified firmware to append the MAC address to the device name, ensuring unique identification for different devices. The device name format is now: NPG-[MAC Address of BLE device].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated BLE device initialization to dynamically generate a unique device name that incorporates the device’s MAC address, enhancing identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->