### PR TITLE
Add detection for all 3 playmates and fix status LED behavior

### DIFF
--- a/NPG-LITE-BLE/NPG-LITE-BLE.ino
+++ b/NPG-LITE-BLE/NPG-LITE-BLE.ino
@@ -326,7 +326,6 @@ void neoPixelTask(void *parameter)
     // run indefinitely when ledBlinkCycles == 0, else run ledBlinkCycles times
     while (ledBlinkCycles != -1 && (ledBlinkCycles == 0 || cycles < (uint8_t)ledBlinkCycles))
     {
-      pixels.clear();
       pixels.setPixelColor(PIXEL_COUNT - 1, pixels.Color(fader, 0, 0));
       pixels.show();
       vTaskDelay(20 / portTICK_PERIOD_MS);

--- a/NPG-LITE-BLE/NPG-LITE-BLE.ino
+++ b/NPG-LITE-BLE/NPG-LITE-BLE.ino
@@ -54,10 +54,12 @@
 // Store chip revision number (for optional raw fixup if needed)
 uint32_t chiprev = efuse_hal_chip_revision();
 #define LED_BUILTIN 7
+#define BUZZER_PIN 8
 #define PIXEL_PIN 15
 #define PIXEL_COUNT 6
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
 #define LED_BUILTIN 6
+#define BUZZER_PIN 8
 #define PIXEL_PIN 3
 #define PIXEL_COUNT 4
 #else
@@ -77,7 +79,7 @@ uint32_t chiprev = efuse_hal_chip_revision();
 static uint8_t NUM_CHANNELS = 4;      // Number of BioAmp channels + 1 channel for battery
 static uint8_t SINGLE_SAMPLE_LEN = 0; // Each sample: (No. of bioAmp channels * 2 bytes) + 1 counter
 static uint16_t NEW_PACKET_LEN = 0;   // Packet length (BLOCK_COUNT * SINGLE_SAMPLE_LEN)
-static bool isBeastPlaymate = false;
+static uint8_t Playmate = 0;          // 0=Explorer(3 channels), 1=Ninja(3 channels), 2=Beast(6 channels)
 
 // Recompute packet sizes to adjust for channel count changes
 static inline void recomputePacketSizes()
@@ -486,39 +488,41 @@ void checkInitialBattery()
 
 // --------Check for Beast Playmate-------
 
-void checkChannelCount()
+void checkPlaymate()
 {
-  isBeastPlaymate = false;
-  // Check for Beast Playmate (6 channels)
-  pinMode(A3, INPUT_PULLUP);
-  pinMode(A4, INPUT_PULLUP);
-  pinMode(A5, INPUT_PULLUP);
-  for (int i = 0; i < 10; i++)
-  { // Collect samples for 10ms
-    isBeastPlaymate = true; // Assume it's a Beast Playmate until we see a high on any of the specific pins
-    if (digitalRead(A3) == HIGH)
-    {
-      isBeastPlaymate = false;
-      break;
-    }
-    if (digitalRead(A4) == HIGH)
-    {
-      isBeastPlaymate = false;
-      break;
-    }
-    if (digitalRead(A5) == HIGH)
-    {
-      isBeastPlaymate = false;
-      break;
-    }
-    vTaskDelay(1 / portTICK_PERIOD_MS);
+  pinMode(LED_BUILTIN, INPUT_PULLUP);
+  pinMode(BUZZER_PIN, INPUT_PULLUP);
+  if(digitalRead(LED_BUILTIN) == HIGH && digitalRead(BUZZER_PIN) == HIGH)
+  {
+    Playmate = 0; // Explorer (3 channels BioAmp, no buzzer and vibration motor)
   }
-  // Restore high-impedance inputs before ADC use
-  pinMode(A3, INPUT);
-  pinMode(A4, INPUT);
-  pinMode(A5, INPUT);
+  else
+  {
+    Playmate = 1; // Assume it's a Ninja Playmate until we detect Beast
+    // Check for Beast Playmate 
+    pinMode(A3, INPUT_PULLUP);
+    pinMode(A4, INPUT_PULLUP);
+    pinMode(A5, INPUT_PULLUP);
+    unsigned long start = millis();
+    while (millis() - start < 100) 
+    {
+      if (digitalRead(A3) == LOW || digitalRead(A4) == LOW || digitalRead(A5) == LOW) 
+      {
+        Playmate = 2;
+        break;
+      }
+    }
+    // Restore high-impedance inputs before ADC use
+    pinMode(A3, INPUT);
+    pinMode(A4, INPUT);
+    pinMode(A5, INPUT);
+  }
+  pinMode(LED_BUILTIN, OUTPUT);
+  pinMode(BUZZER_PIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+  digitalWrite(BUZZER_PIN, LOW);
   // Configure active channels and packet sizes
-  if (isBeastPlaymate)
+  if (Playmate==2) // Beast Playmate with 6 total BioAmp channels
     NUM_CHANNELS = 7;
   else
     NUM_CHANNELS = 4;
@@ -537,7 +541,7 @@ void setup()
 
   setCpuFrequencyMhz(80);
 
-  checkChannelCount(); // Check for Beast Playmate
+  checkPlaymate(); // Check for Beast Playmate
 
   checkInitialBattery(); // Check initial battery status
 
@@ -560,7 +564,7 @@ void setup()
 
   // ----- Initialize BLE -----
   char deviceName[36];
-  if (isBeastPlaymate)
+  if (Playmate==2) // Beast Playmate with 6 total BioAmp channels
     sprintf(deviceName, "NPG-Lite-6CH:%02X:%02X", mac[4], mac[5]);
   else
     sprintf(deviceName, "NPG-Lite-3CH:%02X:%02X", mac[4], mac[5]);

--- a/NPG-LITE-BLE/NPG-LITE-BLE.ino
+++ b/NPG-LITE-BLE/NPG-LITE-BLE.ino
@@ -53,6 +53,7 @@
 #if defined(CONFIG_IDF_TARGET_ESP32C6)
 // Store chip revision number (for optional raw fixup if needed)
 uint32_t chiprev = efuse_hal_chip_revision();
+#define GAIN_PIN 14
 #define LED_BUILTIN 7
 #define BUZZER_PIN 8
 #define PIXEL_PIN 15

--- a/NPG-LITE-BLE/NPG-LITE-BLE.ino
+++ b/NPG-LITE-BLE/NPG-LITE-BLE.ino
@@ -495,12 +495,22 @@ void checkChannelCount()
   pinMode(A5, INPUT_PULLUP);
   for (int i = 0; i < 10; i++)
   { // Collect samples for 10ms
-    if (digitalRead(A3) == LOW)
-      isBeastPlaymate = true;
-    if (digitalRead(A4) == LOW)
-      isBeastPlaymate = true;
-    if (digitalRead(A5) == LOW)
-      isBeastPlaymate = true;
+    isBeastPlaymate = true; // Assume it's a Beast Playmate until we see a high on any of the specific pins
+    if (digitalRead(A3) == HIGH)
+    {
+      isBeastPlaymate = false;
+      break;
+    }
+    if (digitalRead(A4) == HIGH)
+    {
+      isBeastPlaymate = false;
+      break;
+    }
+    if (digitalRead(A5) == HIGH)
+    {
+      isBeastPlaymate = false;
+      break;
+    }
     vTaskDelay(1 / portTICK_PERIOD_MS);
   }
   // Restore high-impedance inputs before ADC use

--- a/NPG-LITE-BLE/NPG-LITE-BLE.ino
+++ b/NPG-LITE-BLE/NPG-LITE-BLE.ino
@@ -47,8 +47,12 @@
 #include "hal/adc_types.h"          // adc_atten_t, bit width, etc.
 #include "soc/soc_caps.h"           // SOC_ADC_DIGI_RESULT_BYTES
 
+// Supported Playmates
+#define PROTO_PLAYMATE 0      // Proto (3 BioAmp channels, no buzzer or vibration motor)
+#define VIBZ_PLAYMATE 1       // Vibz (3 BioAmp channels, buzzer and vibration motor)
+#define VIBZ_PLUS_PLAYMATE 2  // Vibz Plus (6 BioAmp channels, buzzer and vibration motor)
+
 // ----- Chip-specific Pin Definitions -----
-//
 // Use the ESP-IDF config macros to detect the chip.
 #if defined(CONFIG_IDF_TARGET_ESP32C6)
 // Store chip revision number (for optional raw fixup if needed)
@@ -67,7 +71,7 @@ uint32_t chiprev = efuse_hal_chip_revision();
 #error "Unsupported board: Please target either ESP32-C6 or ESP32-C3 in your Board Manager."
 #endif
 
-#define NUM_CHANNELS_MAX 7        // Max channels supported (Beast Playmate)
+#define NUM_CHANNELS_MAX 7        // Max channels supported (Vibz Plus Playmate)
 #define BLE_PAYLOAD_BUFFERS 2     // Number of buffers for BLE payloads to prevent overflow (Change if you need more buffers)
 #define PIXEL_BRIGHTNESS 7        // Brightness of Neopixel LED
 #define BLOCK_COUNT 10            // Batch size: 10 samples per notification
@@ -80,7 +84,7 @@ uint32_t chiprev = efuse_hal_chip_revision();
 static uint8_t NUM_CHANNELS = 4;      // Number of BioAmp channels + 1 channel for battery
 static uint8_t SINGLE_SAMPLE_LEN = 0; // Each sample: (No. of bioAmp channels * 2 bytes) + 1 counter
 static uint16_t NEW_PACKET_LEN = 0;   // Packet length (BLOCK_COUNT * SINGLE_SAMPLE_LEN)
-static uint8_t Playmate = 0;          // 0=Explorer(3 channels), 1=Ninja(3 channels), 2=Beast(6 channels)
+static uint8_t Playmate = PROTO_PLAYMATE; // PROTO_PLAYMATE, VIBZ_PLAYMATE, or VIBZ_PLUS_PLAYMATE
 
 // Recompute packet sizes to adjust for channel count changes
 static inline void recomputePacketSizes()
@@ -486,7 +490,7 @@ void checkInitialBattery()
   }
 }
 
-// --------Check for Beast Playmate-------
+// --------Check Playmate-------
 
 void checkPlaymate()
 {
@@ -494,12 +498,12 @@ void checkPlaymate()
   pinMode(BUZZER_PIN, INPUT_PULLUP);
   if(digitalRead(LED_BUILTIN) == HIGH && digitalRead(BUZZER_PIN) == HIGH)
   {
-    Playmate = 0; // Explorer (3 channels BioAmp, no buzzer and vibration motor)
+    Playmate = PROTO_PLAYMATE;
   }
   else
   {
-    Playmate = 1; // Assume it's a Ninja Playmate until we detect Beast
-    // Check for Beast Playmate 
+    Playmate = VIBZ_PLAYMATE; // Assume Vibz until Vibz Plus is detected
+    // Check for Vibz Plus Playmate
     pinMode(A3, INPUT_PULLUP);
     pinMode(A4, INPUT_PULLUP);
     pinMode(A5, INPUT_PULLUP);
@@ -508,7 +512,7 @@ void checkPlaymate()
     {
       if (digitalRead(A3) == LOW || digitalRead(A4) == LOW || digitalRead(A5) == LOW) 
       {
-        Playmate = 2;
+        Playmate = VIBZ_PLUS_PLAYMATE;
         break;
       }
     }
@@ -522,7 +526,7 @@ void checkPlaymate()
   digitalWrite(LED_BUILTIN, LOW);
   digitalWrite(BUZZER_PIN, LOW);
   // Configure active channels and packet sizes
-  if (Playmate==2) // Beast Playmate with 6 total BioAmp channels
+  if (Playmate == VIBZ_PLUS_PLAYMATE)
     NUM_CHANNELS = 7;
   else
     NUM_CHANNELS = 4;
@@ -541,7 +545,7 @@ void setup()
 
   setCpuFrequencyMhz(80);
 
-  checkPlaymate(); // Check for Beast Playmate
+  checkPlaymate();
 
   checkInitialBattery(); // Check initial battery status
 
@@ -564,7 +568,7 @@ void setup()
 
   // ----- Initialize BLE -----
   char deviceName[36];
-  if (Playmate==2) // Beast Playmate with 6 total BioAmp channels
+  if (Playmate == VIBZ_PLUS_PLAYMATE)
     sprintf(deviceName, "NPG-Lite-6CH:%02X:%02X", mac[4], mac[5]);
   else
     sprintf(deviceName, "NPG-Lite-3CH:%02X:%02X", mac[4], mac[5]);

--- a/NPG-LITE-BLE/NPG-LITE-BLE.ino
+++ b/NPG-LITE-BLE/NPG-LITE-BLE.ino
@@ -522,8 +522,8 @@ void checkPlaymate()
     pinMode(A5, INPUT);
   }
   pinMode(LED_BUILTIN, OUTPUT);
-  pinMode(BUZZER_PIN, OUTPUT);
   digitalWrite(LED_BUILTIN, LOW);
+  pinMode(BUZZER_PIN, OUTPUT);
   digitalWrite(BUZZER_PIN, LOW);
   // Configure active channels and packet sizes
   if (Playmate == VIBZ_PLUS_PLAYMATE)


### PR DESCRIPTION
**1. Added playmate detection for Explorer, Ninja and Beast playmates**
  - Detect Ninja/Beast playmate by checking buzzer pin (8) and vibration motor pin (7) as INPUT_PULLUP
  - Detect Beast playmate by sampling A3, A4, A5 as INPUT_PULLUP for 100 ms
  - Added a Playmate variable: 0 = Explorer, 1 = Ninja, 2 = Beast
  
**2. Fixed status NeoPixel (Index 0) behaviour when battery is less than 10%** 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple hardware device variants with automatic detection
  * Device now automatically configures operation mode and channel settings based on the detected variant type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->